### PR TITLE
fixes #5 - add missing deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ clean:
 deps:
 	go get github.com/flynn/go-shlex
 	go get github.com/mitchellh/packer
+	go get github.com/mitchellh/multistep
+	go get github.com/mitchellh/go-fs
+	go get code.google.com/p/go.crypto/ssh
 
 build:
 	go build -o $(GOPATH)/bin/packer-provisioner-host-command -a


### PR DESCRIPTION
This appears to fix #5 for me, though #6 still prevents a build with current Packer versions.